### PR TITLE
Fix gravity on transformed object

### DIFF
--- a/scenes/grid/grid.gd
+++ b/scenes/grid/grid.gd
@@ -6,3 +6,11 @@ class_name PhysicsGrid
 
 # func _physics_process(delta: float) -> void:
 # 	gravity_direction = -global_basis.y
+
+
+#this fix gravity when transform the node (local direction instead of worldwide gravity definiting) 
+@export var local_gravity_direction := Vector3(0, -1, 0)
+
+func _notification(what: int):
+	if what == NOTIFICATION_TRANSFORM_CHANGED:
+		gravity_direction = global_transform.basis * local_gravity_direction


### PR DESCRIPTION
fix for gravity on transformed object

No sure if it need to be in a parent of physicgrid as the name doesnt really match with what it's currently doing