### PR TITLE
chore(dev-tools): switch off the spawn wheel, the cleanup tool and EVA free-flight

### DIFF
--- a/scenes/globals/globals.gd
+++ b/scenes/globals/globals.gd
@@ -46,6 +46,7 @@ const TERMINATOR_SOFTNESS := 0.05
 const DISABLED_DEV_TOOLS: Dictionary = {
 	"spawn_wheel": true,  # dev spawn wheel (Alt+T) — testing phase over
 	"zapette": true,      # admin cleanup tool (key 2) — testing phase over
+	"toggle_eva": true,   # EVA free-flight ($) — testing phase over, normal play only
 }
 
 ## PLACEHOLDER atmosphere thickness (m) for bodies whose real value is not in the data yet — only

--- a/scenes/globals/globals.gd
+++ b/scenes/globals/globals.gd
@@ -39,6 +39,15 @@ const RENDER_MASK_CELESTIAL := 1 << 19  # layer 20 (value 524288): distant-body 
 ## fades the sun and the sky with it, and each planet pushes it to its surface shaders — all in step.
 const TERMINATOR_SOFTNESS := 0.05
 
+## Dev/test tools that are currently switched OFF, keyed by their InputMap action. Their code and
+## their bindings are kept ON PURPOSE — we will need them again — so this is the single switch:
+## PlayerClient skips building the tool, and the controls menu hides its binding (a key that does
+## nothing must not be rebindable). Delete an entry to bring the tool back, nothing else to change.
+const DISABLED_DEV_TOOLS: Dictionary = {
+	"spawn_wheel": true,  # dev spawn wheel (Alt+T) — testing phase over
+	"zapette": true,      # admin cleanup tool (key 2) — testing phase over
+}
+
 ## PLACEHOLDER atmosphere thickness (m) for bodies whose real value is not in the data yet — only
 ## Tarsis4 (50 km) has one. Lets the altitude fog fade work everywhere until per-body atmosphere data
 ## (derivable from the composition + pressure in tarsis.json) is wired in.
@@ -48,6 +57,10 @@ var player_name: String = "I am an idiot !"
 var player_uuid: String = ""
 var online_mode: bool = false
 var is_gut_running: bool = false
+
+## True when a dev tool is switched off (see DISABLED_DEV_TOOLS).
+static func is_dev_tool_disabled(action: StringName) -> bool:
+	return DISABLED_DEV_TOOLS.has(String(action))
 
 func print_rich_distinguished(message: String, extras: Array) -> void:
 	var peer_id: int = -1

--- a/scenes/player/player_client.gd
+++ b/scenes/player/player_client.gd
@@ -529,7 +529,7 @@ func _unhandled_input(event: InputEvent) -> void:
 		# Settings > Controls to control the torch independently.
 		player.client_send_action_to_server({"action": "toggle_flashlight"})
 
-	if event.is_action_pressed("toggle_eva"):
+	if event.is_action_pressed("toggle_eva") and not Globals.is_dev_tool_disabled("toggle_eva"):
 		# EVA (dev free-flight): just request the toggle; the server owns the state and flies the body
 		# (movement is server-authoritative). Sits before the walk guard so it works in any state.
 		player.client_send_action_to_server({"action": "toggle_eva"})

--- a/scenes/player/player_client.gd
+++ b/scenes/player/player_client.gd
@@ -81,11 +81,14 @@ func setup() -> void:
 	_walk_speed_target = player.walk_speed
 	player.walk_speed_target = _walk_speed_target
 
-	# Dev spawn wheel: hold the spawn key (T) to pick what to spawn.
-	player._spawn_wheel = RadialMenu.new()
-	player._spawn_wheel.title = "Spawn"
-	player.get_node("UserInterface").add_child(player._spawn_wheel)
-	player._spawn_wheel.option_selected.connect(_on_spawn_selected)
+	# Dev spawn wheel: hold the spawn key (Alt+T) to pick what to spawn. Currently switched off (see
+	# Globals.DISABLED_DEV_TOOLS) — the wheel is simply never built, and everything downstream
+	# already handles a null wheel (_service_wheel, _any_wheel_open), so nothing else changes.
+	if not Globals.is_dev_tool_disabled(&"spawn_wheel"):
+		player._spawn_wheel = RadialMenu.new()
+		player._spawn_wheel.title = "Spawn"
+		player.get_node("UserInterface").add_child(player._spawn_wheel)
+		player._spawn_wheel.option_selected.connect(_on_spawn_selected)
 
 	# Emote wheel: hold the emote key (T) to pick an emote (the spawn wheel moved to Alt+T).
 	player._emote_wheel = RadialMenu.new()
@@ -93,11 +96,13 @@ func setup() -> void:
 	player.get_node("UserInterface").add_child(player._emote_wheel)
 	player._emote_wheel.option_selected.connect(_on_emote_selected)
 
-	# Admin cleanup tool (key 2): raycast + red aim line, left click deletes the
-	# targeted player-spawned prop (rock / box / depot) down to the database.
-	player.admin_cleanup_tool = AdminCleanupTool.new()
-	player.add_child(player.admin_cleanup_tool)
-	player.admin_cleanup_tool.setup(player.camera, player)
+	# Admin cleanup tool (key 2): raycast + red aim line, left click deletes the targeted
+	# player-spawned prop (rock / box / depot) down to the database. Currently switched off (see
+	# Globals.DISABLED_DEV_TOOLS) — never built, and its only other caller already null-checks it.
+	if not Globals.is_dev_tool_disabled(&"zapette"):
+		player.admin_cleanup_tool = AdminCleanupTool.new()
+		player.add_child(player.admin_cleanup_tool)
+		player.admin_cleanup_tool.setup(player.camera, player)
 
 	player.global_position = player.spawn_position
 	player.look_at(player.global_transform.origin + Vector3.FORWARD, player.spawn_up)

--- a/scenes/player/player_server.gd
+++ b/scenes/player/player_server.gd
@@ -287,9 +287,14 @@ func server_action_received(data: Dictionary) -> void:
 			# EVA free-flight (dev test aid): flip the authoritative state; _physics_process then flies
 			# the body where the camera looks with no gravity. Zero the velocity so leaving EVA doesn't
 			# fling the player. State-replicated (not the event) so a dropped toggle can't desync it.
-			player.eva_mode = not player.eva_mode
-			player.velocity = Vector3.ZERO
-			player.server_send_properties_to_client({"eva": player.eva_mode})
+			#
+			# Checked HERE as well as on the client, and this is the check that counts: movement is
+			# server-authoritative, so a client that asked anyway — an old build, a modified one —
+			# would still fly. Switching a tool off has to happen where the tool actually runs.
+			if not Globals.is_dev_tool_disabled("toggle_eva"):
+				player.eva_mode = not player.eva_mode
+				player.velocity = Vector3.ZERO
+				player.server_send_properties_to_client({"eva": player.eva_mode})
 		"screen_state":
 			# A 3D screen (mining depot) button was pressed: route it to that screen.
 			if player.screen_interacting and player.screen_interacting.has_method("update_screen"):

--- a/ui/menu_config/menu_config.gd
+++ b/ui/menu_config/menu_config.gd
@@ -35,6 +35,11 @@ func create_action_list():
 	for action in InputMap.get_actions():
 		if action.begins_with("ui_"):
 			continue
+		# A switched-off dev tool keeps its binding in the InputMap (so it can be brought back
+		# without re-adding one), but must not be listed here: rebinding a key that does nothing
+		# would just be confusing. See Globals.DISABLED_DEV_TOOLS.
+		if Globals.is_dev_tool_disabled(action):
+			continue
 		var action_bt = input_button_scene.instantiate()
 		var action_label = action_bt.find_child("LabelAction")
 		var input_label = action_bt.find_child("LabelInput")


### PR DESCRIPTION
## Description

The testing phase for these dev tools is over, so they are switched off for players:

- the **dev spawn wheel** (Alt+T), which spawned rocks, crates, a truck or a depot;
- the **cleanup tool / "zapette"** (key 2), which deleted a targeted player-spawned prop down to the database;
- **EVA free-flight** (`$`), which let a player leave the ground and fly with no gravity and no collision.

**Nothing is deleted.** We will want all three back, so `SpawnCatalog`, `_on_spawn_selected`, `admin_cleanup_tool.gd`, the server-side `spawn_prop` and `toggle_eva` handling, `eva_speed`, `_server_eva_move` and all three InputMap bindings are left exactly as they are.

### How

`Globals.DISABLED_DEV_TOOLS` is the single switch, keyed by InputMap action. It does two things:

1. the client skips the tool — `PlayerClient.setup()` does not build it, and does not send its action;
2. the controls menu hides its binding — offering to rebind a key that does nothing would only be confusing, and keeping the binding in the InputMap means the tool can be restored without re-adding one.

Removing an entry from that dictionary brings a tool back, with no other change anywhere.

### EVA needed the switch in a second place

The spawn wheel and the cleanup tool are client-side objects: never constructing them is enough, because there is nothing left to act.

EVA is not like that. The client only **asks** — `client_send_action_to_server({"action": "toggle_eva"})` — and the **server** owns the state and flies the body. Hiding the key would leave the capability intact for anything that sends the action anyway: an old build, a client that was already running, a modified one. So `PlayerServer.server_action_received` checks the same switch and refuses, and that is the check that counts.

It is worth stating as a rule, since we will switch other things off later: **a tool is switched off where it runs, not where it is triggered.** For anything server-authoritative, the client-side half is only there to keep the UI honest.

### Why no call site had to be neutralised

Everything downstream already handled the tool being absent: `_service_wheel` returns on a null wheel, `_any_wheel_open` null-checks it, and the mining tool null-checks `admin_cleanup_tool` before stowing it. EVA needs nothing either — `eva_mode` simply stays `false`, which is the state every other system already expects. So no code is commented out or gutted.

The emote wheel (plain T) is untouched and keeps working.

### Testing

Played in the editor against a local dedicated server, on top of `feature/NPC2` + #262 — so the
switch is known to hold in the state everything is heading towards, not just against `develop`:

- Alt+T opens nothing; plain T still opens the emote wheel.
- Key 2 no longer activates the cleanup tool (no red aim line, no deletion on click).
- `$` no longer lifts the player: gravity, collision and normal walking are unaffected.
- Settings ▸ Controls lists neither `SPAWN WHEEL`, `ZAPETTE` nor `EVA`; every other action stays rebindable and the search bar still works.
- Equipping the mining tool — the only other code that referenced the cleanup tool — produces no error.

### Merging

No conflict at all with `feature/NPC2`. Against #262 there is a single one, in `globals.gd`, and it
is pure adjacency — that branch adds a clock offset where this one adds `is_dev_tool_disabled()`, at
the same spot in the file. Keep both.

Worth doing this one **after** #262 rather than before: whichever lands second picks up that
adjacency, and rebasing two commits over it is a great deal less work than rebasing nineteen.

One practical note for whoever tests around this: switching the spawn wheel off removes the only way
to put a crate in the world, and the current seed does not contain any (the `box` entries are gone).
Anything that needs something to carry has to be exercised before this merges, or with the entry
temporarily removed from `DISABLED_DEV_TOOLS`.

## Changelog

<!-- CHANGELOG_EN -->
- The developer spawn wheel, the prop cleanup tool and EVA free-flight are no longer available in game, and their shortcuts no longer appear in the control settings.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
- La roue de spawn de développement, l'outil de suppression d'objets et le vol libre EVA ne sont plus accessibles en jeu, et leurs raccourcis n'apparaissent plus dans les réglages de contrôles.
<!-- /CHANGELOG_FR -->
