### PR TITLE
fix(terrain): cliff detection compared the surface normal to a planet-wide constant, and the albedo it was hiding

### DIFF
--- a/assets/_universe/environment/terrain/terrain_biome.gdshader
+++ b/assets/_universe/environment/terrain/terrain_biome.gdshader
@@ -17,6 +17,25 @@ uniform float metallic  : hint_range(0.0, 1.0, 0.01) = 0.0;
 // How much vertex color influences the final albedo (1.0 = full, 0.0 = flat).
 group_uniforms blending;
 uniform float vertex_color_strength : hint_range(0.0, 1.0, 0.01) = 1.0;
+// Scales the final albedo. A knob on the BIOME PALETTE, not a lighting correction.
+//
+// iron_tint() produces vertex colours around 0.82-0.90, which is the reflectance of fresh snow.
+// Light sand sits near 0.35 and powdered corundum near 0.25, so the ground was returning about 2.4x
+// the light it should. Until the cliff bug above was fixed this went unnoticed, because cliff_tint
+// was darkening the entire day side by 30 % and hiding it.
+//
+// Measured at noon on Sandbox, ground against the sky directly above it:
+//   before  ratio 7.78, 64 % of the ground's pixels clipped to white
+//   at 0.40 ratio 3.53, no clipping at all   (light sand is physically 3.2)
+//
+// Lowering EXPOSURE instead would look similar and be wrong: it would darken the sky too, and the
+// sky is correct. That is precisely what the cliff bug was doing by accident.
+//
+// This is a STOPGAP. The real fix belongs in iron_tint(), and the value needs a decision: the
+// atmosphere profile of Sandbox declares ground_albedo = 0.15, which is what pins the planet's
+// published 0.32 albedo and the calibration of mie_beta. 0.15, 0.40 and the 0.64 of KiFouine's
+// corundum material cannot all be right.
+uniform float albedo_multiplier : hint_range(0.05, 1.5, 0.01) = 1.0;
 // A fallback base color used when vertex_color_strength < 1.0.
 uniform vec4 base_color : source_color = vec4(0.45, 0.35, 0.25, 1.0);
 
@@ -323,7 +342,7 @@ void fragment() {
 	// Blend: detail 0.5 = no change, <0.5 darkens, >0.5 brightens.
 	// Using overlay-style blending for natural look.
 	float mod = mix(1.0, detail * 2.0, detail_strength);
-	ALBEDO = clamp(biome_color * mod, vec3(0.0), vec3(1.0));
+	ALBEDO = clamp(biome_color * mod * albedo_multiplier, vec3(0.0), vec3(1.0));
 
 	// Increase roughness on steep cliff faces for a more matte rock look.
 	ROUGHNESS = mix(roughness, min(roughness + 0.1, 1.0), cliff_factor);

--- a/assets/_universe/environment/terrain/terrain_biome.gdshader
+++ b/assets/_universe/environment/terrain/terrain_biome.gdshader
@@ -207,7 +207,20 @@ void fragment() {
 	// path per-fragment.  Computed here (before any texturing) so its VALUE —
 	// not a per-fragment branch — blends the cliff result, keeping the
 	// derivative-based LOD (dFdx in detail_lods) in uniform control flow.
-	vec3 planet_up = normalize(world_pos);
+	// The radial computed in vertex(), NOT normalize(world_pos). The comment on planet_radial_world
+	// above already spells out why: w = 0 drops the model matrix's translation. world_pos keeps it,
+	// and on the CLIENT that translation is the planet's Kepler position -- tarsis_4 orbits at
+	// 0.63-0.67 AU, i.e. ~1e11 m from the universe root, against a 6.36e6 m radius. normalize() of
+	// that returns the star-to-planet direction, which varies by 0.004 degrees across the whole
+	// globe: `slope` was therefore not the local slope at all, but the dot of the surface normal
+	// with a planet-wide constant. Every face on the star-facing hemisphere fell under
+	// cliff_slope_threshold and rendered as cliff -- albedo pulled 30 % toward cliff_tint and
+	// ROUGHNESS forced up -- while genuinely vertical faces elsewhere were missed.
+	//
+	// It only shows on the client: planet_body.gd returns early from _place_at_time() under
+	// Engine.is_editor_hint() or dedicated_server, so in the editor and on the server the planet
+	// sits at the origin and normalize(world_pos) happens to be right. That is why it survived.
+	vec3 planet_up = planet_radial_world;
 	float slope = dot(world_normal, planet_up);  // 1.0 = flat, 0.0 = vertical
 	float cliff_lo = cliff_slope_threshold - cliff_blend_range;
 	float cliff_hi = cliff_slope_threshold + cliff_blend_range;

--- a/assets/_universe/environment/terrain/terrain_biome.tres
+++ b/assets/_universe/environment/terrain/terrain_biome.tres
@@ -118,6 +118,7 @@ render_priority = 0
 shader = ExtResource("shader")
 shader_parameter/roughness = 0.85
 shader_parameter/metallic = 0.0
+shader_parameter/albedo_multiplier = 0.4
 shader_parameter/vertex_color_strength = 1.0
 shader_parameter/base_color = Color(0.45, 0.35, 0.25, 1)
 shader_parameter/detail_textures = SubResource("Texture2DArray_6er27")


### PR DESCRIPTION
## Description

`terrain_biome.gdshader` decided whether a surface is a cliff with

```glsl
vec3 planet_up = normalize(world_pos);
float slope = dot(world_normal, planet_up);
```

which assumes the planet sits at the world origin. **On the client it does not.** `planet_body.gd`
places each body at its Kepler position, and Tarsis IV orbits at 0.63–0.67 AU — about 1e11 m from
the universe root, against a 6.36e6 m radius. `normalize()` of that returns the star-to-planet
direction, which varies by **0.004° across the entire globe**.

`slope` was therefore never the local slope. It was the dot product of the surface normal with a
fixed direction, so every face on the star-facing hemisphere fell under `cliff_slope_threshold`.

### Measured in game

A temporary diagnostic painted both verdicts into one frame — red where only the old vector says
"cliff", green where only the new one does:

| | share of visible terrain |
|---|---|
| red — false positives of the old vector | **50.6 %** |
| yellow — both agree | 17.8 % |
| green — real faces the old vector missed | **15.7 %** |
| black — flat ground, neither | 15.9 % |

So the old code treated **68 %** of the visible terrain as cliff when only **33 %** is: albedo pulled
30 % toward `cliff_tint`, `ROUGHNESS` raised, and the rock detail texture blended in — on flat
ground. Meanwhile a sixth of the genuine vertical faces went without any of it.

### The fix

Use `planet_radial_world`, which `vertex()` already computes four lines above, with a comment
spelling out this exact hazard: it multiplies by the model matrix with `w = 0`, which drops the
translation. The far-terminator correction was given that vector; the slope path was left behind.

### Why it survived this long

It is invisible wherever one usually looks. `planet_body.gd:236` returns early from
`_place_at_time()` under `Engine.is_editor_hint()` or `dedicated_server`, so **in the editor and on
the server the planet really is at the origin** and `normalize(world_pos)` is correct. Only the
client is affected — which is the only place anyone sees the terrain.

### Note for reviewers

This visibly **brightens the ground**, because the cliff tint was acting as an accidental global
darkener over the whole day side. That is the bug being removed, not a regression — but it does mean
the biome palette (`iron_tint()` returns vertex colours around 0.82–0.90, i.e. near-white) is now
shown as it really is, and may want its own pass.

Found while investigating something unrelated in the atmosphere renderer.

## Changelog

<!-- CHANGELOG_EN -->
Fixed cliff detection on planet surfaces: steep faces are now correctly identified everywhere,
instead of the whole star-facing hemisphere being rendered as cliff and genuine vertical faces being
missed.
<!-- /CHANGELOG_EN -->

<!-- CHANGELOG_FR -->
Correction de la détection des falaises : les parois raides sont désormais reconnues correctement
partout, au lieu que tout l'hémisphère éclairé soit rendu comme une falaise et que de vraies parois
verticales soient ignorées.
<!-- /CHANGELOG_FR -->

---

## Second commit: the albedo that came out from under the bug

Fixing the cliff test removes a 30 % darkening that was being applied to most of the star-facing
hemisphere, and that darkening was hiding a second problem.

`iron_tint()` produces vertex colours of **0.82 to 0.90**, which is the reflectance of fresh snow.
Light sand is 0.35 and powdered corundum 0.25, so the ground returns roughly **2.4x** the light it
should. Nobody noticed, because the cliff bug was shading it down by accident.

Measured at noon on Sandbox, the ground against the sky directly above it:

| | ground / sky | clipped pixels |
|---|---|---|
| before | 7.78 | 64 % of the ground |
| `albedo_multiplier = 0.40` | 3.53 | none |

Light sand under a clear sky is physically around 3.2, so 0.40 lands where it should.

Lowering **exposure** instead would look similar and be wrong: it darkens the sky too, and the sky is
correct. That is precisely what the cliff bug was doing by accident.

### This one is a stopgap, deliberately

The multiplier is a knob on the biome palette, not a lighting correction. The durable fix belongs in
`iron_tint()`, but it needs a decision that is not mine to make, because three sources disagree on how
bright Sandbox's ground actually is:

- the atmosphere profile declares `ground_albedo = 0.15`, which is what pins the planet's published
  **0.32** bond albedo and the calibration of `mie_beta`
- the corundum material uses **0.64**
- the shader was effectively rendering **0.85**

They cannot all be right, and picking one changes the atmosphere's calibration as well as the terrain's
look. Shipping the multiplier keeps the ground readable in the meantime, and it is a single uniform to
delete once the palette itself is corrected.
